### PR TITLE
Rename section to avoid implying split DNS

### DIFF
--- a/draft-tjjk-cared.md
+++ b/draft-tjjk-cared.md
@@ -196,7 +196,7 @@ For example, an encrypted DNS server owned by an enterprise that
 only allows connections from devices managed by that same enterprise
 might require clients to authenticate.
 
-## Resolving names differently per client {#per-client}
+## Refusing to resolve different names per client {#per-client}
 
 An encrypted DNS server that provides client-specific resolution
 behaviour MAY require clients to authenticate in circumstances


### PR DESCRIPTION
"resolving differently" could mean resolving to something else (breaks DNSSEC and my heart) or to resolve or not to resolve (which is the question, with no regard for whether 'tis nobler in either direction).

This is in response to Stephen's response on the uta list.

@jdamick and @ableyjoe 